### PR TITLE
Add quadlet support

### DIFF
--- a/erlantzoniga.com.build
+++ b/erlantzoniga.com.build
@@ -1,0 +1,3 @@
+[Build]
+ImageTag=localhost/erlantzoniga.com:latest
+SetWorkingDirectory=unit

--- a/erlantzoniga.com.container
+++ b/erlantzoniga.com.container
@@ -1,0 +1,10 @@
+[Unit]
+Description=Erlantzoniga.com personal website
+
+[Container]
+Image=erlantzoniga.com.build
+PublishPort=8080:80
+AddHost=erlantzoniga.com:127.0.0.1
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This change introduces quadlet support for running the personal website as a systemd service using Podman.

It adds two files:
- `erlantzoniga.com.build`: A `.build` file that defines how to build the container image from the existing `Dockerfile`.
- `erlantzoniga.com.container`: A `.container` file that defines the systemd service for running the container. It references the build file, publishes port 8080, and is configured to start on boot.